### PR TITLE
show only nlmaps topics in forum section

### DIFF
--- a/docs/app/js/app.js
+++ b/docs/app/js/app.js
@@ -5,6 +5,6 @@ import Docs from './_docs';
 
 $(() => {
     new Maps();
-    new Forum('https://geoforum.nl', 'applicaties-en-diensten/nl-maps');
+    new Forum('https://geoforum.nl', 'nl-maps');
     new Docs('kadaster/nlmaps/', 'docs/README-NL.md');
 });


### PR DESCRIPTION
op dit moment toont de website ook geoforum topics die niet onder nlmaps vallen:

![image](https://user-images.githubusercontent.com/3216462/111786031-a39b6a00-88bd-11eb-9497-28e3010e10ed.png)

deze commit verhelpt dat.

