### PR TITLE
fix bootstrap-sass issue in docs

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "serve": "npx http-server ./build -p 8081"
   },
   "dependencies": {
-    "bootstrap-sass": "^3.3.7",
+    "bootstrap-sass": "3.4.1",
     "browser-detect": "^0.2.18",
     "clipboard": "^1.6.1",
     "jquery": "^3.5.0",


### PR DESCRIPTION
for hosting nlmaps by pdok we build from the docs dir using gulp in node 6.x. there is no package lock there. recently apparently a backwards incompatibility issue entered in bootstrap-sass: https://github.com/twbs/bootstrap-sass/issues/1228#issuecomment-1069310370

quick "fix" here to pin the version of bootstrap-sass to 3.4.1 (before that issue)