### PR TITLE
Change geocoder URLs from the deprecated geodata.nationaalgeoregister nl to api.pdok.nl

### DIFF
--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -137,8 +137,8 @@ A collection of arrays with classnames to be added to interface elements. This c
         ]
     },
     "geocoder": {
-        "suggestUrl": "https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest?",
-        "lookupUrl": "https://geodata.nationaalgeoregister.nl/locatieserver/v3/lookup?"
+        "suggestUrl": "https://api.pdok.nl/bzk/locatieserver/search/v3_1/suggest?",
+        "lookupUrl": "https://api.pdok.nl/bzk/locatieserver/search/v3_1/lookup?"
     },
     "map": {
         "style": 'standaard',

--- a/packages/config/config.js
+++ b/packages/config/config.js
@@ -88,8 +88,8 @@ export default {
         ]
     },
     "geocoder": {
-        "suggestUrl": "https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest?",
-        "lookupUrl": "https://geodata.nationaalgeoregister.nl/locatieserver/v3/lookup?",
+        "suggestUrl": "https://api.pdok.nl/bzk/locatieserver/search/v3_1/suggest?",
+        "lookupUrl": "https://api.pdok.nl/bzk/locatieserver/search/v3_1/lookup?",
         "placeholder": "Zoomen naar adres ..."
     },
     "map": {

--- a/packages/nlmaps/test/testconfig.js
+++ b/packages/nlmaps/test/testconfig.js
@@ -92,8 +92,8 @@ export default {
         ]
     },
     "geocoder": {
-        "suggestUrl": "https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest?",
-        "lookupUrl": "https://geodata.nationaalgeoregister.nl/locatieserver/v3/lookup?"
+        "suggestUrl": "https://api.pdok.nl/bzk/locatieserver/search/v3_1/suggest?",
+        "lookupUrl": "https://api.pdok.nl/bzk/locatieserver/search/v3_1/lookup?"
     },
     "featureQuery": {
         "baseUrl": "https://api.data.amsterdam.nl/bag/nummeraanduiding/?format=json&locatie=",


### PR DESCRIPTION
See https://www.pdok.nl/-/urgent-oude-url-s-pdok-locatieserver-per-2-augustus-uit-productie.

Fixes #167.