### PR TITLE
fix: change nlmaps-leaflet dependency specifier

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "leaflet": "^1.9.4",
-    "@geo-frontend/nlmaps-leaflet": "^1.0.0",
+    "@geo-frontend/nlmaps-leaflet": "1.0.0",
     "vite": "^5.4.14",
     "vue": "^3.5.13"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
   apps/website:
     dependencies:
       '@geo-frontend/nlmaps-leaflet':
-        specifier: workspace:*
+        specifier: 1.0.0
         version: link:../../packages/nlmaps-leaflet
       leaflet:
         specifier: ^1.9.4


### PR DESCRIPTION
Project would not build with the configured specifier, giving `Failed to resolve entry for package "@geo-frontend/nlmaps-leaflet"` errors. Aligned the dependency specifier in `apps/website/package.json` and `pnpm-lock.yaml` with those used for `packages/nlmaps`. Project builds with this change.